### PR TITLE
Avalon overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <groupId>org.fcrepo</groupId>
-  <version>6.4.0-SNAPSHOT</version>
+  <version>6.3.0-AVALON</version>
   <artifactId>fcrepo-upgrade-utils</artifactId>
   <name>Fedora Repository Utilities</name>
   <description>The Fedora Commons repository upgrade utilities: Provides tools for maintaining the Fedora Commons

--- a/src/main/java/org/fcrepo/upgrade/utils/Config.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/Config.java
@@ -219,6 +219,13 @@ public class Config {
     }
 
     /**
+     * @return the extension of the rdf lang of the export
+     */
+    public String getSrcRdfExt() {
+        return srcRdfLang.getFileExtensions().get(0);
+    }
+
+    /**
      * Sets the rdf lang of the export
      * @param srcRdfLang the rdf lang of the export
      */

--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -90,7 +90,6 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     private static final String FCR_VERSIONS_PATH_SEGMENT = "fcr%3Aversions";
     private static final String FCR_ACL_PATH_SEGMENT = "fcr%3Aacl";
     private static final String TYPE_RELATION = "type";
-    private static final String TURTLE_EXTENSION = ".ttl";
     private static final String HEADERS_SUFFIX = ".headers";
     public static final String APPLICATION_OCTET_STREAM_MIMETYPE = "application/octet-stream";
     /**
@@ -120,7 +119,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     private void processFile(final Path path) {
 
         //skip versions container
-        if (path.endsWith(FCR_VERSIONS_PATH_SEGMENT + TURTLE_EXTENSION)) {
+        if (path.endsWith(FCR_VERSIONS_PATH_SEGMENT + "." + config.getSrcRdfExt())) {
             LOGGER.debug("version containers are not required for import.  Skipping {}...", path);
             return;
         }
@@ -145,7 +144,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
             Files.createDirectories(newLocation.getParent());
             LOGGER.debug("copy file {} to {}", path, newLocation);
             FileUtils.copyFile(path.toFile(), newLocation.toFile());
-            if (newLocation.toString().endsWith(TURTLE_EXTENSION)) {
+            if (newLocation.toString().endsWith(config.getSrcRdfExt())) {
                 upgradeRdfAndCreateHeaders(versionTimestamp, newLocation);
             }
             LOGGER.info("Resource upgraded: {}", path);
@@ -321,7 +320,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         //locate the exported acl rdf on disk based on aclURI
         final var relativeAclPath = create(aclUri).getPath();
         final var aclDirectory = Path.of(this.config.getInputDir().toPath().toString(), relativeAclPath);
-        final var aclRdfFilePath = aclDirectory + TURTLE_EXTENSION;
+        final var aclRdfFilePath = aclDirectory + "." + config.getSrcRdfExt();
         final var newAclResource = ResourceFactory.createResource(protectedResource + "/fcr:acl");
         final var aclModel = createModelFromFile(Path.of(aclRdfFilePath));
         final var aclTriples = new ArrayList<Statement>();
@@ -338,7 +337,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
         final var newAclFilePath = Path
             .of(FilenameUtils.removeExtension(convertedProtectedResourceLocation.toString()),
-                FCR_ACL_PATH_SEGMENT + TURTLE_EXTENSION);
+                FCR_ACL_PATH_SEGMENT + "." + config.getSrcRdfExt());
         newAclFilePath.getParent().toFile().mkdirs();
 
         //determine the location of new acl
@@ -422,7 +421,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         while (currentPath != path.getRoot()) {
             final var parent = currentPath.getParent();
             if (parent.endsWith(FCR_VERSIONS_PATH_SEGMENT)) {
-                return Path.of(parent.toString() + TURTLE_EXTENSION);
+                return Path.of(parent.toString() + "." + config.getSrcRdfExt());
             }
 
             currentPath = parent;
@@ -432,10 +431,10 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
     private TemporalAccessor resolveMementoTimestamp(final Path path) {
         var metadataPath = path;
-        if (!path.toString().endsWith(TURTLE_EXTENSION)) {
+        if (!path.toString().endsWith(config.getSrcRdfExt())) {
             final var metadataPathStr = metadataPath.toString();
             final var newMetadataPathStr = FilenameUtils.removeExtension(metadataPathStr) + File.separator +
-                                           FCR_METADATA_PATH_SEGMENT + TURTLE_EXTENSION;
+                                           FCR_METADATA_PATH_SEGMENT + "." + config.getSrcRdfExt();
             metadataPath = Path.of(newMetadataPathStr);
         }
 
@@ -466,7 +465,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     private Path resolveNewVersionedResourceLocation(final Path path, final TemporalAccessor mementoTimestamp) {
         final var mementoId = MEMENTO_FORMATTER.format(mementoTimestamp);
         //create a new location compatible with an F5 export.
-        final var isDescription = path.endsWith(FCR_METADATA_PATH_SEGMENT + TURTLE_EXTENSION);
+        final var isDescription = path.endsWith(FCR_METADATA_PATH_SEGMENT + "." + config.getSrcRdfExt());
         final var inputPath = this.config.getInputDir().toPath();
         final var relativePath = inputPath.relativize(path);
         final var relativePathStr = relativePath.toString();

--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -160,7 +160,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         //parse the file
         final Model model = ModelFactory.createDefaultModel();
         try (final InputStream is = new BufferedInputStream(new FileInputStream(newLocation.toFile()))) {
-            RDFDataMgr.read(model, is, Lang.TTL);
+            RDFDataMgr.read(model, is, config.getSrcRdfLang());
         }
 
         final Map<String, List<String>> metadataHeaders = new HashMap<>();
@@ -283,7 +283,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         // rewrite only if the model has changed.
         if (rewriteModel.get()) {
             try {
-                RDFDataMgr.write(new BufferedOutputStream(new FileOutputStream(newLocation.toFile())), model, Lang.TTL);
+                RDFDataMgr.write(new BufferedOutputStream(new FileOutputStream(newLocation.toFile())), model, config.getSrcRdfLang());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -384,7 +384,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
         //save to new acl to file
         try (final OutputStream os = new BufferedOutputStream(new FileOutputStream(newAclFilePath.toFile()))) {
-            RDFDataMgr.write(os, newModel, Lang.TTL);
+            RDFDataMgr.write(os, newModel, config.getSrcRdfLang());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -455,7 +455,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     private Model createModelFromFile(final Path path) {
         final Model model = ModelFactory.createDefaultModel();
         try (final InputStream is = new BufferedInputStream(new FileInputStream(path.toFile()))) {
-            RDFDataMgr.read(model, is, Lang.TTL);
+            RDFDataMgr.read(model, is, config.getSrcRdfLang());
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -182,10 +182,10 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
         //skip if ACL or Authorization: these files are upgraded through a separate code path
         // see convertAcl() below.
-        if (rdfTypes.contains(ACL) || rdfTypes.contains(AUTHORIZATION)) {
-            newLocation.toFile().delete();
-            return;
-        }
+        //if (rdfTypes.contains(ACL) || rdfTypes.contains(AUTHORIZATION)) {
+        //    newLocation.toFile().delete();
+        //    return;
+        //}
 
         rdfTypes.retainAll(LDP_CONTAINER_TYPES);
         final var isConcreteContainerDefined = !rdfTypes.isEmpty();
@@ -251,17 +251,17 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
                     }
                 }
                 binaryHeaders.put(CONTENT_TYPE_HEADER, Collections.singletonList(mimetype));
-            } else if (statement.getPredicate().equals(ACCESS_CONTROL)) {
+            //} else if (statement.getPredicate().equals(ACCESS_CONTROL)) {
                 //remove the current statement across both past versions and latest version
-                model.remove(currentStatement);
-                rewriteModel.set(true);
+                //model.remove(currentStatement);
+                //rewriteModel.set(true);
 
                 //on the latest version
-                if(versionTimestamp == null) {
-                    //convert the acl
-                    convertAcl(newLocation, currentStatement.getSubject().getURI(),
-                               currentStatement.getObject().asResource().getURI());
-                }
+                //if(versionTimestamp == null) {
+                //    //convert the acl
+                //    convertAcl(newLocation, currentStatement.getSubject().getURI(),
+                //               currentStatement.getObject().asResource().getURI());
+                //}
             }
         });
 

--- a/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
@@ -96,7 +96,8 @@ public class RdfConstants {
     private static final Set<Property> serverManagedProperties;
     static {
         final ImmutableSet.Builder<Property> b = ImmutableSet.builder();
-        b.addAll(fixityProperties).addAll(ldpManagedProperties).addAll(binaryProperties);
+        //b.addAll(fixityProperties).addAll(ldpManagedProperties).addAll(binaryProperties);
+        b.addAll(fixityProperties).addAll(ldpManagedProperties);
         serverManagedProperties = b.build();
     }
 

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceMigrator.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceMigrator.java
@@ -90,7 +90,7 @@ public class ResourceMigrator {
 
         this.baseUri = stripTrailingSlash(config.getBaseUri());
         this.srcRdfLang = config.getSrcRdfLang();
-        this.srcRdfExt = "." + srcRdfLang.getFileExtensions().get(0);
+        this.srcRdfExt = "." + config.getSrcRdfExt();
 
         // Currently, this is all F6 supports
         this.dstRdfLang = Lang.NT;


### PR DESCRIPTION
List of changes in this PR:
- Don't handle ebucore:filename specially since Avalon uses it
- Ignore ACL triples because samvera ACLs are different than fedora ACLs
- Correctly handle ntriples exports when migrating 4->5->6